### PR TITLE
Resolves #2

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Data/Message.cs
+++ b/src/Application/src/RazorPagesTestSample/Data/Message.cs
@@ -7,9 +7,18 @@ namespace RazorPagesTestSample.Data
     {
         public int Id { get; set; }
 
+        /// <summary>
+        /// Gets or sets the text of the message.
+        /// </summary>
+        /// <remarks>
+        /// The text should be a string with a maximum length of 250 characters.
+        /// </remarks>
+        /// <value>
+        /// The text of the message.
+        /// </value>
         [Required]
         [DataType(DataType.Text)]
-        [StringLength(200, ErrorMessage = "There's a 200 character limit on messages. Please shorten your message.")]
+        [StringLength(250, ErrorMessage = "There's a 250 character limit on messages. Please shorten your message.")]
         public string Text { get; set; }
     }
     #endregion


### PR DESCRIPTION
This pull request includes a small but significant update to the `Message` class in the `RazorPagesTestSample` project. The change involves updating the maximum length of the `Text` property and adding comprehensive documentation comments.

* [`src/Application/src/RazorPagesTestSample/Data/Message.cs`](diffhunk://#diff-3ce635672d23bd9cdaa8656d8d117fc07bbea38b87de905339a765df73f3c450R10-R21): Updated the maximum length of the `Text` property from 200 to 250 characters and added XML documentation comments for the `Text` property.